### PR TITLE
About Sleep Information HTML Sanitization

### DIFF
--- a/aws_portal/frontend/src/components/adminDashboard/aboutSleepTemplatesEdit.tsx
+++ b/aws_portal/frontend/src/components/adminDashboard/aboutSleepTemplatesEdit.tsx
@@ -16,6 +16,7 @@ import FormSummaryButton from "../containers/forms/formSummaryButton";
 import sanitize from "sanitize-html";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useFlashMessageContext } from "../../contexts/flashMessagesContext";
+import QuillField from "../fields/quillField";
 
 /**
  * The form's prefill
@@ -163,17 +164,15 @@ const AboutSleepTemplatesEdit = () => {
         </FormRow>
         <FormRow>
           <FormField>
-            <TextField
+            <QuillField
               id="text"
-              type="textarea"
-              value={text}
+              containerClassName="ql-container-form"
               label="Text"
-              onKeyup={setText} />
+              description="This is what the user will see when they view the About Sleep screen on the mobile app."
+              value={text}
+              onChange={setText}
+            />
           </FormField>
-        </FormRow>
-        <FormTitle className="mt-6">Preview</FormTitle>
-        <FormRow>
-          <div ref={previewRef} className="px-4" />
         </FormRow>
       </Form>
       <FormSummary>

--- a/aws_portal/views/admin.py
+++ b/aws_portal/views/admin.py
@@ -1289,6 +1289,7 @@ def about_sleep_template_create():
         data = request.json["create"]
         about_sleep_template = AboutSleepTemplate()
 
+        data["text"] = sanitizer.sanitize(data["text"])
         populate_model(about_sleep_template, data)
         db.session.add(about_sleep_template)
         db.session.commit()
@@ -1342,6 +1343,11 @@ def about_sleep_template_edit():
         about_sleep_template = AboutSleepTemplate.query.get(
             about_sleep_template_id
         )
+
+        try:
+            data["text"] = sanitizer.sanitize(data["text"])
+        except KeyError:
+            pass
 
         populate_model(about_sleep_template, data)
         db.session.commit()


### PR DESCRIPTION
- Added frontend and backend sanitization for about sleep templates.
- The frontend now uses the `QuillField`.