### PR TITLE
Set Up Logging Before Importing the App

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from logging.config import dictConfig
 import os
 
 from flask import Flask, Response, request
@@ -32,23 +31,6 @@ from backend.views import (
 )
 from backend.views.auth import participant_auth_blueprint, researcher_auth_blueprint
 from backend.views.api import fitbit
-
-
-dictConfig({
-    "version": 1,
-    "formatters": {"default": {
-        "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
-    }},
-    "handlers": {"wsgi": {
-        "class": "logging.StreamHandler",
-        "stream": "ext://flask.logging.wsgi_errors_stream",
-        "formatter": "default"
-    }},
-    "root": {
-        "level": "INFO",
-        "handlers": ["wsgi"]
-    }
-})
 
 
 def create_app(testing=False):

--- a/run.py
+++ b/run.py
@@ -14,11 +14,29 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from logging.config import dictConfig
 import os
 
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
+
+# Set up logging before importing the app
+dictConfig({
+    "version": 1,
+    "formatters": {"default": {
+        "format": "[%(asctime)s] %(levelname)s in %(module)s: %(message)s",
+    }},
+    "handlers": {"wsgi": {
+        "class": "logging.StreamHandler",
+        "stream": "ext://flask.logging.wsgi_errors_stream",
+        "formatter": "default"
+    }},
+    "root": {
+        "level": "INFO",
+        "handlers": ["wsgi"]
+    }
+})
 
 # if the app is running in a production environment
 if os.getenv("FLASK_CONFIG") in {"Production", "Staging"}:


### PR DESCRIPTION
# Set Up Logging Before Importing the App

## Summary

Set up logging in `run.py` before importing the app so that all logger instances inherit the same config.

## Changes

- Moved `dictConfig` from `app.py` to `run.py` to set up configuration before importing the app.

## How to Test

1. Run the app as normal.
2. Stop the local postgres container.
3. `curl` http://localhost:5000/health.
4. Check that a connection error with the postgres container is properly logged.

## Checklist

- [x] New code includes a license statement.
- [x] Any TODOs are made into new issues.
- [x] Code is properly linted (for Markdown, TypeScript, and Python).
- [x] Unit tests are written for any new code.
- [x] All existing unit tests pass.
- [x] Any changes to the database schema include a migration script that does not result in data loss (if applicable).
- [x] Any new endpoints include proper AWS Cognito and/or RBAC protections (if applicable).
