### PR TITLE
SQLAlchemy with IAM Authentication

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -203,7 +203,12 @@ def register_extensions(app):
         expose_headers=app.config.get("CORS_EXPOSE_HEADERS"),
         supports_credentials=app.config.get("CORS_SUPPORTS_CREDENTIALS", True),
     )
-    db.init_app(app)
+
+    if app.config["ENV"] in ["development", "testing"]:
+        db.init_app(app, use_iam=False)
+    else:
+        db.init_app(app, use_iam=True)
+
     jwt.init_app(app)
     migrate.init_app(app, db)
     tm.init_app(app)

--- a/backend/extensions.py
+++ b/backend/extensions.py
@@ -16,12 +16,12 @@ from flask_caching import Cache
 from flask_cors import CORS
 from flask_jwt_extended import JWTManager
 from flask_migrate import Migrate
-from flask_sqlalchemy import SQLAlchemy
 
+from shared.iam_sqlalchemy import IamSqlAlchemy
 from shared.tokens_manager import TokensManager
 
 cors = CORS()
-db = SQLAlchemy()
+db = IamSqlAlchemy()
 jwt = JWTManager()
 migrate = Migrate()
 cache = Cache(config={"CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_TIMEOUT": 7200})

--- a/shared/iam_sqlalchemy.py
+++ b/shared/iam_sqlalchemy.py
@@ -1,0 +1,86 @@
+# Copyright 2025 The Trustees of the University of Pennsylvania
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may]
+# not use this file except in compliance with the License. You may obtain a
+# copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from typing import Any
+
+import boto3
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Dialect, event
+from sqlalchemy.pool import ConnectionPoolEntry
+
+
+class IamSqlAlchemy(SQLAlchemy):
+    def init_app(
+        self,
+        app: Flask,
+        use_iam: bool = False,
+        iam_sslmode: str = "require",
+        **kwargs,
+    ):
+        """
+        Initialize the SQLAlchemy extension.
+
+        This extends the SQLAlchemy extension to use IAM authentication when
+        use_iam is True.
+
+        Args
+        ----
+            app: The Flask application instance.
+            use_iam: Whether to use IAM authentication.
+            sslmode: The SSL mode to use.
+            **kwargs: Additional keyword arguments to pass to the SQLAlchemy
+                extension.
+
+        Example Usage
+        -------------
+        >>> from flask import Flask
+        >>> from shared.iam_sqlalchemy import IamSqlAlchemy
+
+        >>> app = Flask(__name__)
+        >>> db = IamSqlAlchemy()
+        >>> db.init_app(app, use_iam=True)
+        """
+        super().init_app(app, **kwargs)
+        self.client = boto3.client("rds")
+
+        with app.app_context():
+
+            @event.listens_for(self.engine, "do_connect")
+            def provide_token(
+                dialect: Dialect,  # noqa: ARG001
+                conn_rec: ConnectionPoolEntry,  # noqa: ARG001
+                cargs: tuple[Any, ...],  # noqa: ARG001
+                cparams: dict[str, Any],
+            ):
+                if use_iam:
+                    cparams["sslmode"] = iam_sslmode
+                    cparams["password"] = self.create_auth_token(
+                        hostname=cparams["host"],
+                        port=cparams["port"],
+                        username=cparams["user"],
+                    )
+
+    def create_auth_token(
+        self, *, hostname: str, port: int, username: str
+    ) -> str:
+        """Create an IAM authentication token for the given database URI and username."""
+        try:
+            auth_token = self.client.generate_db_auth_token(
+                DBHostname=hostname,
+                Port=port,
+                DBUsername=username,
+            )
+        except Exception:
+            raise
+
+        return auth_token

--- a/shared/iam_sqlalchemy.py
+++ b/shared/iam_sqlalchemy.py
@@ -10,6 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import logging
 from typing import Any, Literal
 
 import boto3
@@ -17,6 +18,8 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import Dialect, event
 from sqlalchemy.pool import ConnectionPoolEntry
+
+logger = logging.getLogger(__name__)
 
 type SSLMode = Literal["require", "prefer"]
 
@@ -85,7 +88,8 @@ class IamSqlAlchemy(SQLAlchemy):
                 Port=port,
                 DBUsername=username,
             )
-        except Exception:
+        except Exception as e:
+            logger.error(f"Failed to create IAM authentication token: {e!s}")
             raise
 
         return auth_token

--- a/shared/iam_sqlalchemy.py
+++ b/shared/iam_sqlalchemy.py
@@ -46,7 +46,7 @@ class IamSqlAlchemy(SQLAlchemy):
         ----
             app: The Flask application instance.
             use_iam: Whether to use IAM authentication.
-            sslmode: The SSL mode to use.
+            iam_sslmode: The SSL mode to use.
             **kwargs: Additional keyword arguments to pass to the SQLAlchemy
                 extension.
 

--- a/shared/iam_sqlalchemy.py
+++ b/shared/iam_sqlalchemy.py
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-from typing import Any
+from typing import Any, Literal
 
 import boto3
 from flask import Flask
@@ -18,13 +18,19 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import Dialect, event
 from sqlalchemy.pool import ConnectionPoolEntry
 
+type SSLMode = Literal["require", "prefer"]
+
 
 class IamSqlAlchemy(SQLAlchemy):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.client = boto3.client("rds")
+
     def init_app(
         self,
         app: Flask,
         use_iam: bool = False,
-        iam_sslmode: str = "require",
+        iam_sslmode: SSLMode = "require",
         **kwargs,
     ):
         """
@@ -51,7 +57,6 @@ class IamSqlAlchemy(SQLAlchemy):
         >>> db.init_app(app, use_iam=True)
         """
         super().init_app(app, **kwargs)
-        self.client = boto3.client("rds")
 
         with app.app_context():
 

--- a/tests/tests_shared/test_iam_sqlalchemy.py
+++ b/tests/tests_shared/test_iam_sqlalchemy.py
@@ -1,0 +1,138 @@
+# Copyright 2025 The Trustees of the University of Pennsylvania
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may]
+# not use this file except in compliance with the License. You may obtain a
+# copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from moto import mock_aws
+from sqlalchemy import Dialect, event, text
+from sqlalchemy.pool import ConnectionPoolEntry
+
+from shared.iam_sqlalchemy import IamSqlAlchemy
+
+
+@pytest.fixture
+def mock_app():
+    app = Flask(__name__)
+    app.config["SQLALCHEMY_DATABASE_URI"] = (
+        "postgresql://username:password@localhost:5432/postgres"
+    )
+    return app
+
+
+@pytest.fixture
+def mock_db():
+    db = IamSqlAlchemy()
+    db.client.generate_db_auth_token = MagicMock()
+    return db
+
+
+def set_connection_test(app: Flask, db: IamSqlAlchemy, test_func: Callable):
+    with app.app_context():
+
+        @event.listens_for(db.engine, "do_connect")
+        def test_do_connect(
+            dialect: Dialect,
+            conn_rec: ConnectionPoolEntry,
+            cargs: tuple[Any, ...],
+            cparams: dict[str, Any],
+        ):
+            test_func(cparams)
+
+
+class TestIamSqlAlchemy:
+    """Test cases for the IamSqlAlchemy class."""
+
+    def test_init_app_without_iam(self, mock_app: Flask, mock_db: IamSqlAlchemy):
+        """Test init_app when use_iam is False."""
+        mock_db.init_app(mock_app, use_iam=False)
+
+        def test_func(cparams: dict[str, Any]):
+            assert cparams.get("sslmode") is None
+            assert cparams["password"] == "password"  # noqa: S105
+
+        set_connection_test(mock_app, mock_db, test_func)
+
+        with mock_app.app_context():
+            mock_db.session.execute(text("SELECT 1"))
+
+        mock_db.client.generate_db_auth_token.assert_not_called()
+
+    def test_init_app_with_iam(self, mock_app: Flask, mock_db: IamSqlAlchemy):
+        """Test init_app when use_iam is True."""
+        mock_db.init_app(mock_app, use_iam=True)
+
+        def test_func(cparams: dict[str, Any]):
+            assert cparams["sslmode"] == "require"
+            assert cparams["password"] != "password"  # noqa: S105
+            # Reset auth to avoid an authentication error
+            del cparams["sslmode"]
+            cparams["password"] = "password"  # noqa: S105
+
+        set_connection_test(mock_app, mock_db, test_func)
+
+        with mock_app.app_context():
+            mock_db.session.execute(text("SELECT 1"))
+
+        mock_db.client.generate_db_auth_token.assert_called_once_with(
+            DBHostname="localhost", Port=5432, DBUsername="username"
+        )
+
+    def test_init_app_with_custom_ssl_mode(
+        self, mock_app: Flask, mock_db: IamSqlAlchemy
+    ):
+        """Test init_app with custom SSL mode."""
+        mock_db.init_app(mock_app, use_iam=True, iam_sslmode="prefer")
+
+        def test_func(cparams: dict[str, Any]):
+            assert cparams["sslmode"] == "prefer"
+            # Reset auth to avoid an authentication error
+            del cparams["sslmode"]
+            cparams["password"] = "password"  # noqa: S105
+
+        set_connection_test(mock_app, mock_db, test_func)
+
+        with mock_app.app_context():
+            mock_db.session.execute(text("SELECT 1"))
+
+    @mock_aws
+    def test_create_auth_token_exception_propagation(
+        self, mock_app: Flask, mock_db: IamSqlAlchemy
+    ):
+        """Test that exceptions from boto3 are properly propagated."""
+        mock_db.init_app(mock_app, use_iam=True)
+
+        # Create a mock RDS client that raises an exception
+        mock_db.client.generate_db_auth_token.side_effect = Exception("AWS Error")
+
+        with pytest.raises(Exception, match="AWS Error"), mock_app.app_context():
+            mock_db.session.execute(text("SELECT 1"))
+
+    def test_init_app_with_additional_kwargs(self, mock_app: Flask):
+        """Test that additional kwargs are passed to the parent init_app method."""
+        db = IamSqlAlchemy(
+            engine_options={"connect_args": {"dbname": "test-dbname"}}
+        )
+        db.init_app(mock_app)
+
+        def test_func(cparams: dict[str, Any]):
+            assert cparams["dbname"] == "test-dbname"
+            # Reset auth to avoid an authentication error
+            cparams["dbname"] = "postgres"
+
+        set_connection_test(mock_app, db, test_func)
+
+        with mock_app.app_context():
+            db.session.execute(text("SELECT 1"))

--- a/tests/tests_shared/test_iam_sqlalchemy.py
+++ b/tests/tests_shared/test_iam_sqlalchemy.py
@@ -10,13 +10,13 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+import os
 from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 from flask import Flask
-from moto import mock_aws
 from sqlalchemy import Dialect, event, text
 from sqlalchemy.pool import ConnectionPoolEntry
 
@@ -26,9 +26,7 @@ from shared.iam_sqlalchemy import IamSqlAlchemy
 @pytest.fixture
 def mock_app():
     app = Flask(__name__)
-    app.config["SQLALCHEMY_DATABASE_URI"] = (
-        "postgresql://username:password@localhost:5432/postgres"
-    )
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("FLASK_DB")
     return app
 
 
@@ -37,6 +35,21 @@ def mock_db():
     db = IamSqlAlchemy()
     db.client.generate_db_auth_token = MagicMock()
     return db
+
+
+@pytest.fixture
+def db_uri_params():
+    uri = os.getenv("FLASK_DB")
+    print(uri)
+    x = {
+        "hostname": uri.split("@")[1].split(":")[0],
+        "port": int(uri.split(":")[3].split("/")[0]),
+        "database": uri.split("/")[-1],
+        "username": uri.split("@")[0].split(":")[1][2:],
+        "password": uri.split("@")[0].split(":")[2],
+    }
+    print(x)
+    return x
 
 
 def set_connection_test(app: Flask, db: IamSqlAlchemy, test_func: Callable):
@@ -55,13 +68,18 @@ def set_connection_test(app: Flask, db: IamSqlAlchemy, test_func: Callable):
 class TestIamSqlAlchemy:
     """Test cases for the IamSqlAlchemy class."""
 
-    def test_init_app_without_iam(self, mock_app: Flask, mock_db: IamSqlAlchemy):
+    def test_init_app_without_iam(
+        self,
+        mock_app: Flask,
+        mock_db: IamSqlAlchemy,
+        db_uri_params: dict[str, Any],
+    ):
         """Test init_app when use_iam is False."""
         mock_db.init_app(mock_app, use_iam=False)
 
         def test_func(cparams: dict[str, Any]):
             assert cparams.get("sslmode") is None
-            assert cparams["password"] == "password"  # noqa: S105
+            assert cparams["password"] == db_uri_params["password"]
 
         set_connection_test(mock_app, mock_db, test_func)
 
@@ -70,16 +88,21 @@ class TestIamSqlAlchemy:
 
         mock_db.client.generate_db_auth_token.assert_not_called()
 
-    def test_init_app_with_iam(self, mock_app: Flask, mock_db: IamSqlAlchemy):
+    def test_init_app_with_iam(
+        self,
+        mock_app: Flask,
+        mock_db: IamSqlAlchemy,
+        db_uri_params: dict[str, Any],
+    ):
         """Test init_app when use_iam is True."""
         mock_db.init_app(mock_app, use_iam=True)
 
         def test_func(cparams: dict[str, Any]):
             assert cparams["sslmode"] == "require"
-            assert cparams["password"] != "password"  # noqa: S105
+            assert cparams["password"] != db_uri_params["password"]
             # Reset auth to avoid an authentication error
             del cparams["sslmode"]
-            cparams["password"] = "password"  # noqa: S105
+            cparams["password"] = db_uri_params["password"]
 
         set_connection_test(mock_app, mock_db, test_func)
 
@@ -87,11 +110,16 @@ class TestIamSqlAlchemy:
             mock_db.session.execute(text("SELECT 1"))
 
         mock_db.client.generate_db_auth_token.assert_called_once_with(
-            DBHostname="localhost", Port=5432, DBUsername="username"
+            DBHostname=db_uri_params["hostname"],
+            Port=db_uri_params["port"],
+            DBUsername=db_uri_params["username"],
         )
 
     def test_init_app_with_custom_ssl_mode(
-        self, mock_app: Flask, mock_db: IamSqlAlchemy
+        self,
+        mock_app: Flask,
+        mock_db: IamSqlAlchemy,
+        db_uri_params: dict[str, Any],
     ):
         """Test init_app with custom SSL mode."""
         mock_db.init_app(mock_app, use_iam=True, iam_sslmode="prefer")
@@ -100,16 +128,18 @@ class TestIamSqlAlchemy:
             assert cparams["sslmode"] == "prefer"
             # Reset auth to avoid an authentication error
             del cparams["sslmode"]
-            cparams["password"] = "password"  # noqa: S105
+            cparams["password"] = db_uri_params["password"]
 
         set_connection_test(mock_app, mock_db, test_func)
 
         with mock_app.app_context():
             mock_db.session.execute(text("SELECT 1"))
 
-    @mock_aws
     def test_create_auth_token_exception_propagation(
-        self, mock_app: Flask, mock_db: IamSqlAlchemy
+        self,
+        mock_app: Flask,
+        mock_db: IamSqlAlchemy,
+        db_uri_params: dict[str, Any],
     ):
         """Test that exceptions from boto3 are properly propagated."""
         mock_db.init_app(mock_app, use_iam=True)
@@ -120,7 +150,9 @@ class TestIamSqlAlchemy:
         with pytest.raises(Exception, match="AWS Error"), mock_app.app_context():
             mock_db.session.execute(text("SELECT 1"))
 
-    def test_init_app_with_additional_kwargs(self, mock_app: Flask):
+    def test_init_app_with_additional_kwargs(
+        self, mock_app: Flask, db_uri_params: dict[str, Any]
+    ):
         """Test that additional kwargs are passed to the parent init_app method."""
         db = IamSqlAlchemy(
             engine_options={"connect_args": {"dbname": "test-dbname"}}
@@ -130,7 +162,7 @@ class TestIamSqlAlchemy:
         def test_func(cparams: dict[str, Any]):
             assert cparams["dbname"] == "test-dbname"
             # Reset auth to avoid an authentication error
-            cparams["dbname"] = "postgres"
+            cparams["dbname"] = db_uri_params["database"]
 
         set_connection_test(mock_app, db, test_func)
 

--- a/tests/tests_shared/test_iam_sqlalchemy.py
+++ b/tests/tests_shared/test_iam_sqlalchemy.py
@@ -14,6 +14,7 @@ import os
 from collections.abc import Callable
 from typing import Any
 from unittest.mock import MagicMock
+from urllib.parse import urlparse
 
 import pytest
 from flask import Flask
@@ -40,16 +41,14 @@ def mock_db():
 @pytest.fixture
 def db_uri_params():
     uri = os.getenv("FLASK_DB")
-    print(uri)
-    x = {
-        "hostname": uri.split("@")[1].split(":")[0],
-        "port": int(uri.split(":")[3].split("/")[0]),
-        "database": uri.split("/")[-1],
-        "username": uri.split("@")[0].split(":")[1][2:],
-        "password": uri.split("@")[0].split(":")[2],
+    parsed = urlparse(uri)
+    return {
+        "hostname": parsed.hostname,
+        "port": parsed.port,
+        "database": parsed.path.lstrip("/"),
+        "username": parsed.username,
+        "password": parsed.password,
     }
-    print(x)
-    return x
 
 
 def set_connection_test(app: Flask, db: IamSqlAlchemy, test_func: Callable):


### PR DESCRIPTION
# SQLAlchemy with IAM Authentication

## Summary

This PR overrides the `flask_sqlalchemy.SQLAlchemy` class with a custom `IamSqlAlchemy` class that enables IAM authentication via boto3.

## Changes

- Added a `IamSqlAlchemy` class to `shared/iam_sqlalchemy.py` that overrides Flask SQLAlchemy's `init_app` function.
  - `init_app` now receives two keyword arguments: `use_iam` and `iam_sslmode`.
  - When `use_iam` is true, the `iam_sslmode` ("required" or "preferred") is applied to the connection and an auth token generated by boto3 is used as the password.
- Updated `app.py` and `extensions.py` to use the new `IamSqlAlchemy` class.
  - `use_iam` is set to `False` when the runtime environment is "development" or "testing," and set to `True` otherwise.
- Added unit tests to `tests/tests_shared/test_iam_sqlalchemy.py`.

## How to Test

**Note:** This PR alone does not contain changes required to test in a staging environment.

1. Run unit tests and ensure all pass.
2. Run the application locally and ensure the `/health` endpoint returns successfully.

## Checklist

- [x] New code includes a license statement.
- [x] Any TODOs are made into new issues.
- [x] Code is properly linted (for Markdown, TypeScript, and Python).
- [x] Unit tests are written for any new code.
- [x] All existing unit tests pass.